### PR TITLE
Cadastro dados duplicados produtor (email,cnpj)

### DIFF
--- a/Cadastro_produtor.php
+++ b/Cadastro_produtor.php
@@ -11,14 +11,26 @@
 </head>
 <?php
 session_start();
-if(isset($_SESSION['duplicate'])){
+if(isset($_SESSION['duplicate_cnpj'])){
+?>
+<script>
+    alert('Cnpj already registered.')
+
+</script>
+ <?php
+    unset($_SESSION['duplicate_cnpj']);    }
+
+        ?>
+<?php
+
+if(isset($_SESSION['duplicate_email'])){
 ?>
 <script>
     alert('Email already registered.')
 
 </script>
  <?php
-    unset($_SESSION['duplicate']);    }
+    unset($_SESSION['duplicate_email']);    }
 
         ?>
 

--- a/Insert_info_produtor.php
+++ b/Insert_info_produtor.php
@@ -9,12 +9,19 @@ $password=$_POST['pass'];
 
 
 
-$sql1= "Select email from infos where email='$email'";
-$result= $conn->query($sql1);
-if($result->num_rows >0){
+$sql1= "Select email_prod from infos_prod where email_prod='$email'";
+$sql2=  "Select cnpj from infos_prod where cnpj='$cnpj'";
+$result_email= $conn->query($sql1);
+$result_cnpj= $conn->query($sql2);
+if($result_email->num_rows >0){
         session_start();
-        $_SESSION['duplicate']=True;
+        $_SESSION['duplicate_email']=True;
         header('Location: Cadastro_produtor.php');
+}
+elseif($result_cnpj->num_rows > 0){
+    session_start();
+    $_SESSION['duplicate_cnpj']=True;
+    header('Location: Cadastro_produtor.php');
 }
 
 else{


### PR DESCRIPTION
- Arrumei o codigo para que o produtor nao posse se cadastrar com um email ou cnpj que ja esta presente no banco de dados. Se ele coloca um cnpj/email que ja esta no banco de dados ele vai retornar para o cadastro de produtor mostrando uma mensagem .